### PR TITLE
Configuración Básica LGFX para usar TFT_eSPI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,12 @@
-#define LGFX_AUTODETECT
 
 #include <LovyanGFX.hpp>
 
 #include "lgfx_CUSTOMBOARD_conf.hpp"
 
-static LGFX lcd;                 // Instance of LGFX
-static LGFX_Sprite sprite(&lcd); // Instance of LGFX_Sprite when using sprites
+#include <LGFX_TFT_eSPI.hpp>
+
+static TFT_eSPI lcd;                 // Instance of LGFX
+static TFT_eSprite sprite(&lcd); // Instance of LGFX_Sprite when using sprites
 
 // If you are currently using TFT_eSPI and want to minimize changes to your
 // code, you can use this header.


### PR DESCRIPTION
Te adjunto los cambios para poder usar LovyanGFX en sustitución de TFT_eSPI, si pones lo que hay en el main donde se define el LCD podrás usar esta librería (optimizada para ESP) en todos los proyectos que tengas TFT_eSPI sin cambiar nada de lo que ya tengas puesto